### PR TITLE
Migrate to SpringDoc

### DIFF
--- a/services/build.gradle
+++ b/services/build.gradle
@@ -5,9 +5,6 @@ plugins {
     id 'jacoco'
 }
 
-def springfoxVersion = '3.0.0'
-def springfoxUiVersion = '2.9.2'
-
 group = 'com.jos.dem.jmailer'
 
 configurations {
@@ -28,8 +25,7 @@ dependencies {
     implementation 'org.hibernate:hibernate-validator:5.3.0.Final'
     implementation 'org.freemarker:freemarker:2.3.31'
     implementation 'org.apache.activemq:activemq-broker'
-    implementation "io.springfox:springfox-swagger2:${springfoxVersion}"
-    implementation "io.springfox:springfox-swagger-ui:${springfoxUiVersion}"
+    implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
     implementation 'org.codehaus.groovy:groovy'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -5,9 +5,6 @@ plugins {
     id 'jacoco'
 }
 
-def springfoxVersion = '3.0.0'
-def springfoxUiVersion = '2.9.2'
-
 group = 'com.jos.dem.jmailer'
 version = '1.0.10'
 
@@ -32,8 +29,7 @@ dependencies {
     implementation 'org.codehaus.groovy:groovy'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    implementation "io.springfox:springfox-swagger2:${springfoxVersion}"
-    implementation "io.springfox:springfox-swagger-ui:${springfoxUiVersion}"
+    implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
     implementation project(':services')
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'

--- a/web/src/main/java/com/jos/dem/jmailer/config/SwaggerConfig.java
+++ b/web/src/main/java/com/jos/dem/jmailer/config/SwaggerConfig.java
@@ -16,45 +16,30 @@ limitations under the License.
 
 package com.jos.dem.jmailer.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
-import java.util.Set;
 
 @Configuration
-@EnableSwagger2
 @RequiredArgsConstructor
 public class SwaggerConfig {
 
-  private final ApplicationProperties applicationProperties;
+    private final ApplicationProperties applicationProperties;
 
-  @Bean
-  public Docket createDocket() {
-    return new Docket(DocumentationType.SWAGGER_2)
-            .useDefaultResponseMessages(false)
-            .protocols(Set.of("https", "http"))
-            .apiInfo(apiInfo())
-            .select()
-            .apis(RequestHandlerSelectors.basePackage(applicationProperties.getBasePackage()))
-            .build();
-  }
+    @Bean
+    public OpenAPI springShopOpenAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .title(applicationProperties.getTitle())
+                                .description(applicationProperties.getDescription())
+                                .version(applicationProperties.getVersion())
+                                .termsOfService(applicationProperties.getTerms())
+                );
+    }
 
-  private ApiInfo apiInfo() {
-    return new ApiInfoBuilder()
-            .title(applicationProperties.getTitle())
-            .description(applicationProperties.getDescription())
-            .termsOfServiceUrl(applicationProperties.getTerms())
-            .version(applicationProperties.getVersion())
-            .build();
-  }
 }
 
 

--- a/web/src/main/java/com/jos/dem/jmailer/controller/EmailerController.java
+++ b/web/src/main/java/com/jos/dem/jmailer/controller/EmailerController.java
@@ -20,10 +20,10 @@ import com.jos.dem.jmailer.command.FormCommand;
 import com.jos.dem.jmailer.command.MessageCommand;
 import com.jos.dem.jmailer.exception.BusinessException;
 import com.jos.dem.jmailer.service.EmailerService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -41,7 +41,7 @@ import javax.validation.Valid;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
 @Slf4j
-@Api(tags = "Knows how to send emails")
+@Tag(name="email", description = "Knows how to send emails")
 @RequestMapping("/emailer/*")
 @RestController
 @RequiredArgsConstructor
@@ -55,12 +55,12 @@ public class EmailerController {
   @Value("${email.redirect}")
   private String redirectUrl;
 
-  @ApiOperation(value = "Send an email with JSON")
+  @Operation(summary = "Send an email with JSON")
   @ApiResponses(
       value = {
-        @ApiResponse(code = 200, message = "User created"),
-        @ApiResponse(code = 400, message = "Bad request"),
-        @ApiResponse(code = 500, message = "Something went wrong")
+        @ApiResponse(responseCode = "200", description = "User created"),
+        @ApiResponse(responseCode = "400", description = "Bad request"),
+        @ApiResponse(responseCode = "500", description = "Something went wrong")
       })
   @RequestMapping(method = POST, value = "/message", consumes = "application/json")
   public ResponseEntity<String> message(@RequestBody MessageCommand command) {


### PR DESCRIPTION
This PR replaces springfox with springdoc still using Spring Boot 2.x
Migration from springdoc for Spring Boot 2.x to springdoc for Spring Boot 3.x will be done in https://github.com/josdem/jmailer-spring-boot/pull/44

Closes: #45 