### PR TITLE
Update dependencies to the latest version

### DIFF
--- a/services/build.gradle.kts
+++ b/services/build.gradle.kts
@@ -2,14 +2,14 @@ import io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension
 
 plugins {
     java
-    id("org.springframework.boot") version "3.4.1"
+    id("org.springframework.boot") version "3.4.2"
     id("io.spring.dependency-management") version "1.1.7"
     id ("com.diffplug.spotless") version "7.0.2"
     id ("java")
     id ("jacoco")
 }
 
-val springdocVersion = "2.8.3"
+val springdocVersion = "2.8.4"
 val freeMarkerVersion = "2.3.34"
 
 group = "com.josdem.jmailer"
@@ -50,7 +50,6 @@ dependencies {
     compileOnly ("org.projectlombok:lombok")
     annotationProcessor ("org.projectlombok:lombok")
     testImplementation ("org.springframework.boot:spring-boot-starter-test")
-    testImplementation ("io.projectreactor:reactor-test")
     testCompileOnly ("org.projectlombok:lombok")
     testAnnotationProcessor ("org.projectlombok:lombok")
 }

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -2,14 +2,14 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
     java
-    id("org.springframework.boot") version "3.4.1"
+    id("org.springframework.boot") version "3.4.2"
     id("io.spring.dependency-management") version "1.1.7"
     id ("com.diffplug.spotless") version "7.0.2"
     id ("java")
     id ("jacoco")
 }
 
-val springdocVersion = "2.8.3"
+val springdocVersion = "2.8.4"
 val freeMarkerVersion = "2.3.34"
 
 group = "com.josdem.jmailer"


### PR DESCRIPTION
Fixes #115

Update dependencies to the latest version.

* Update Spring Boot version to `3.4.2` in `services/build.gradle.kts` and `web/build.gradle.kts`.
* Update SpringDoc version to `2.8.4` in `services/build.gradle.kts` and `web/build.gradle.kts`.
* Remove the unused dependency `io.projectreactor:reactor-test` from `services/build.gradle.kts`.

